### PR TITLE
Use image tags from docker/metadata-action.

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -48,16 +48,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: lowercase owner name
-        run: |
-            echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
-        env:
-            OWNER: '${{ github.repository_owner }}'
       - name: Docker Meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{env.OWNER_LC}}/key4hep-externals
+          images: ${{ github.repository_owner }}/key4hep-externals
       - name: Determine spack ref
         id: getref
         run: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -23,8 +23,6 @@ jobs:
     strategy:
       matrix:
         os: [{dir: AlmaLinux9,suffix: alma9}]
-    env:
-      IMAGE_NAME: key4hep-externals
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: endersonmenezes/free-disk-space@v2
@@ -59,7 +57,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{env.OWNER_LC}}/key4hep-dummy
+          images: ${{env.OWNER_LC}}/key4hep-externals
       - name: Determine spack ref
         id: getref
         run: |
@@ -75,5 +73,5 @@ jobs:
             GITHUB_REPOSITORY=${{ github.repository }}
             COMMIT_SHA=${{ github.sha }}
             SPACK_COMMIT=${{ steps.getref.outputs.spack_ref }}
-          tags: ${{ env.REGISTRY }}/${{env.OWNER_LC}}/${{ env.IMAGE_NAME}}:${{steps.meta.outputs.version}}-${{matrix.os.suffix}}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Use the `docker/metadata-action` step to generate the image tags. Previously only parts of the output were taken to handle multiple image names in the muon collider workflow. This is no longer needed.

The lower-casing of the image name is also removed. The `docker/metadata-action` does this for us as part of the image name sanitization.